### PR TITLE
Add support for ls

### DIFF
--- a/colorize.plugin.zsh
+++ b/colorize.plugin.zsh
@@ -13,6 +13,10 @@ DEPENDENCES_DEBIAN+=( grc )
 
 export LESS="$LESS -R -M"
 
+function ls() {
+  command ls --color=auto "$@"
+}
+
 function ip() {
   command ip -color "$@"
 }


### PR DESCRIPTION
In `ls --help`:

```
      --color[=WHEN]         colorize the output; WHEN can be 'always' (default
                               if omitted), 'auto', or 'never'; more info below
```