### PR TITLE
Change -R to -r to make it handle utf-8

### DIFF
--- a/colorize.plugin.zsh
+++ b/colorize.plugin.zsh
@@ -12,7 +12,7 @@ if [[ $PMSPEC != *b* ]] {
 DEPENDENCES_ARCH+=( grc )
 DEPENDENCES_DEBIAN+=( grc )
 
-export LESS="$LESS -R -M"
+LESS="-r -M $LESS"
 
 function ip() {
   command ip -color "$@"


### PR DESCRIPTION
Refer <https://serverfault.com/questions/414760/how-to-make-the-less-command-handle-utf-8>

```shell
unset LESS
less -R -M
```

will result in wrong utf-8

![screen-2023-05-24-19-00-17](https://github.com/zpm-zsh/colorize/assets/32936898/260833e0-d837-47d2-ac14-1c27ec584656)
and `less -r -M` can work.

I change the order of `-r -M` and `$LESS` to allow user to use `$LESS` to override `-r -M`

and it doesn't need `export`, and it will be `source` due to it is a plugin.
