### PR TITLE
Make less colors look better

### DIFF
--- a/colorize.plugin.zsh
+++ b/colorize.plugin.zsh
@@ -22,10 +22,10 @@ export GCC_COLORS
 # Less Colors
 export LESS="-r -M $LESS"
 
-export LESS_TERMCAP_mb="${c[green]}"
-export LESS_TERMCAP_md="${c[bold]}${c[blue]}${c[bg_black]}"
-export LESS_TERMCAP_so="${c[bold]}${c[bg_yellow]}${c[black]}"
-export LESS_TERMCAP_us="${c[green]}"
+export LESS_TERMCAP_mb="${c[green]}" # start blink
+export LESS_TERMCAP_md="${c[bold]}${c[springgreen]}${c[coursive]}" # start bold
+export LESS_TERMCAP_so="${c[bold]}${c[bg_yellow]}${c[black]}" # start standout
+export LESS_TERMCAP_us="${c[underline]}${c[azure]}" # start underline
 
 export LESS_TERMCAP_ue="${c[reset]}"
 export LESS_TERMCAP_me="${c[reset]}"


### PR DESCRIPTION
Hello! I changed the `LESS_TERMCAP` variables to make it look better (in my opinion), by removing the black background and utilizing more features supported by https://github.com/zpm-zsh/colors.

Here's some screenshots before the change, using different terminal themes:

![2023-12-11-213749_hyprshot](https://github.com/zpm-zsh/colorize/assets/72336775/5ac35ecf-4ff3-423e-ba00-05b156be2e5d)
![2023-12-11-213812_hyprshot](https://github.com/zpm-zsh/colorize/assets/72336775/8582a3f8-9b85-4f9e-a3a2-03b1845c9dea)
![2023-12-11-213825_hyprshot](https://github.com/zpm-zsh/colorize/assets/72336775/638bda0f-a3b2-4e3f-96cf-62c765a4181c)

As shown in the screenshots, black backgrounds doesn look quite good in light themes.

Here's some screenshots after the change:

![2023-12-11-213423_hyprshot](https://github.com/zpm-zsh/colorize/assets/72336775/89b41064-301d-4b42-99fe-d7e5e3669e34)
![2023-12-11-213531_hyprshot](https://github.com/zpm-zsh/colorize/assets/72336775/126282db-240e-404e-b563-68234d125b5e)
![2023-12-11-213606_hyprshot](https://github.com/zpm-zsh/colorize/assets/72336775/55a3eac1-a0b8-44bf-ab23-7ad5f099fd2f)

